### PR TITLE
Fix the error 'Unable to set a shared secret on a null device' 

### DIFF
--- a/src/android/com/handpoint/cordova/HandpointHelper.java
+++ b/src/android/com/handpoint/cordova/HandpointHelper.java
@@ -120,6 +120,12 @@ public class HandpointHelper implements Events.Required, Events.Status, Events.L
   }
 
   public void setSharedSecret(CallbackContext callbackContext, JSONObject params) throws Throwable {
+
+    // Set Shared secret only if there is a connected Device
+    if (this.api.getConnectionStatus() == ConnectionStatus.Connected) {
+      this.api.setSharedSecret(params.getString("sharedSecret"));
+    }
+
     // Set as default shared secret
     this.api.defaultSharedSecret(params.getString("sharedSecret"));
     callbackContext.success("ok");

--- a/src/android/com/handpoint/cordova/HandpointHelper.java
+++ b/src/android/com/handpoint/cordova/HandpointHelper.java
@@ -28,7 +28,7 @@ public class HandpointHelper implements Events.Required, Events.Status, Events.L
     this.context = context;
   }
 
-  //An Android Context is required to be able to handle bluetooth
+  // An Android Context is required to be able to handle bluetooth
   public void setup(CallbackContext callbackContext, JSONObject params) throws Throwable {
     String sharedSecret = null;
 
@@ -120,7 +120,8 @@ public class HandpointHelper implements Events.Required, Events.Status, Events.L
   }
 
   public void setSharedSecret(CallbackContext callbackContext, JSONObject params) throws Throwable {
-    this.api.setSharedSecret(params.getString("sharedSecret"));
+    // Set as default shared secret
+    this.api.defaultSharedSecret(params.getString("sharedSecret"));
     callbackContext.success("ok");
   }
 
@@ -178,7 +179,7 @@ public class HandpointHelper implements Events.Required, Events.Status, Events.L
   }
 
   /**
-   * Register event handler 
+   * Register event handler
    */
   public void eventHandler(CallbackContext callbackContext, JSONObject params) throws Throwable {
     this.callbackContext = callbackContext;


### PR DESCRIPTION
Fix the error 'Unable to set a shared secret on a null device' by using SDK method defaultSharedSecret instead of setSharedSecret