### PR TITLE
[android] Dates comming from the SDK are not properly serialized

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -11,6 +11,7 @@
     <clobbers target="cordova.plugins.Handpoint"/>
   </js-module>
   <platform name="android">
+    <source-file src="src/android/com/handpoint/cordova/GsonUTCDateAdapter.java" target-dir="src/com/handpoint/cordova"/>
     <source-file src="src/android/com/handpoint/cordova/HandpointApiCordova.java" target-dir="src/com/handpoint/cordova"/>
     <source-file src="src/android/com/handpoint/cordova/HandpointHelper.java" target-dir="src/com/handpoint/cordova"/>
     <source-file src="src/android/com/handpoint/cordova/SDKEvent.java" target-dir="src/com/handpoint/cordova"/>

--- a/src/android/com/handpoint/cordova/GsonUTCDateAdapter.java
+++ b/src/android/com/handpoint/cordova/GsonUTCDateAdapter.java
@@ -1,0 +1,29 @@
+package com.handpoint.cordova;
+
+import java.text.*;
+import java.util.Date;
+import java.util.TimeZone;
+import com.google.gson.*;
+import java.lang.reflect.Type;
+
+public class GsonUTCDateAdapter implements JsonSerializer<Date>,JsonDeserializer<Date> {
+
+  private final DateFormat dateFormat;
+
+  public GsonUTCDateAdapter() {
+    dateFormat = new SimpleDateFormat("yyyyMMddHHmmss");
+    dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+  }
+
+  @Override public synchronized JsonElement serialize(Date date,Type type,JsonSerializationContext jsonSerializationContext) {
+      return new JsonPrimitive(dateFormat.format(date));
+  }
+
+  @Override public synchronized Date deserialize(JsonElement jsonElement,Type type,JsonDeserializationContext jsonDeserializationContext) {
+    try {
+      return dateFormat.parse(jsonElement.getAsString());
+    } catch (ParseException e) {
+      throw new JsonParseException(e);
+    }
+  }
+}

--- a/src/android/com/handpoint/cordova/SDKEvent.java
+++ b/src/android/com/handpoint/cordova/SDKEvent.java
@@ -1,9 +1,13 @@
 package com.handpoint.cordova;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.AbstractCollection;
 import com.google.gson.*;
@@ -32,7 +36,7 @@ public class SDKEvent {
    * Add event data. Each entry in event data is a key/value pair
    */
   public void put(String key, Object value) {
-    Gson gson = new Gson();
+    Gson gson = new GsonBuilder().registerTypeAdapter(Date.class, new GsonUTCDateAdapter()).create();
     ArrayList list = new ArrayList();
     Iterator iterator = null;
     JSONObject valueObject = null;
@@ -49,6 +53,10 @@ public class SDKEvent {
         }
         valueObjectList = new JSONArray(list);
         data.put(key, valueObjectList);
+      } else if (value instanceof Date) {
+        DateFormat formatter = new SimpleDateFormat("yyyyMMddHHmmss");
+        formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+        this.data.put(key, formatter.format((Date) value));
       } else if (value instanceof Enum) {
         this.data.put(key, this.sanitize(value.toString()));
       } else if (value instanceof String) {


### PR DESCRIPTION
There are two problems when the plugin serializes the field **transactionResult.eFTTimestamp**:
- Format is not the same in Android and iOS. In Android the timestamp is returned in the format: "Sep 3, 2018 4:02:24 AM"
- In Android this date is not UTC
Change the android implementation and format dates as "yyyyMMddHHmmss" in **UTC**