### PR TITLE
Add libDeviceConfig.so to PAX code base 

### DIFF
--- a/src/android/pax.gradle
+++ b/src/android/pax.gradle
@@ -12,7 +12,7 @@ repositories{
 dependencies {
    implementation 'com.google.code.gson:gson:2.8.5'
    implementation 'org.slf4j:slf4j-android:1.7.25'
-   implementation ('com.handpoint.api:sdk:5.2.0-RC.4-SNAPSHOT') { changing = true }   
+   implementation ('com.handpoint.api:sdk:5.2.0-RC.5-SNAPSHOT') { changing = true }   
 }
 
 android {
@@ -29,6 +29,7 @@ android {
         exclude 'META-INF/NOTICE.txt'
         exclude 'META-INF/notice.txt'
         exclude 'META-INF/ASL2.0'
+	pickFirst 'lib/armeabi/libDeviceConfig.so'
     }
 }
 


### PR DESCRIPTION
- Fix [EFTCLIENT-3467](https://handpoint.atlassian.net/browse/EFTCLIENT-3467): Add  libDeviceConfig.so to PAX code base 