### PR TITLE
EFTCLIENT-4934

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -14,6 +14,18 @@
     <clobbers target="cordova.plugins.Handpoint" />
   </js-module>
   <platform name="android">
+    <source-file src="src/android/com/handpoint/cordova/sim/GetSimInfoOperation.java"
+      target-dir="src/com/handpoint/cordova/sim" />
+    <source-file src="src/android/com/handpoint/cordova/sim/HasSimReadPermissionOperation.java"
+      target-dir="src/com/handpoint/cordova/sim" />
+    <source-file src="src/android/com/handpoint/cordova/sim/RequestSimReadPermissionOperation.java"
+      target-dir="src/com/handpoint/cordova/sim" />
+    <source-file src="src/android/com/handpoint/cordova/sim/BaseSimOperation.java"
+      target-dir="src/com/handpoint/cordova/sim" />
+    <source-file src="src/android/com/handpoint/cordova/sim/SimOperation.java"
+      target-dir="src/com/handpoint/cordova/sim" />
+    <source-file src="src/android/com/handpoint/cordova/sim/SimOperationFactory.java"
+      target-dir="src/com/handpoint/cordova/sim" />
     <source-file src="src/android/com/handpoint/cordova/GsonUTCDateAdapter.java"
       target-dir="src/com/handpoint/cordova" />
     <source-file src="src/android/com/handpoint/cordova/HandpointApiCordova.java"
@@ -25,6 +37,8 @@
     <source-file src="src/android/com/handpoint/cordova/GsonPaymentScenarioAdapter.java"
       target-dir="src/com/handpoint/cordova" />
     <source-file src="src/android/com/handpoint/cordova/GsonTenderTypeAdapter.java"
+      target-dir="src/com/handpoint/cordova" />
+    <source-file src="src/android/com/handpoint/cordova/PermissionResultObserver.java"
       target-dir="src/com/handpoint/cordova" />
     <config-file target="res/xml/config.xml" parent="/*">
       <feature name="HandpointApiCordova">

--- a/src/android/com/handpoint/cordova/PermissionResultObserver.java
+++ b/src/android/com/handpoint/cordova/PermissionResultObserver.java
@@ -1,0 +1,5 @@
+package com.handpoint.cordova;
+
+public interface PermissionResultObserver {
+  void onPermissionResult(int requestCode, boolean isGranted);
+}

--- a/src/android/com/handpoint/cordova/sim/BaseSimOperation.java
+++ b/src/android/com/handpoint/cordova/sim/BaseSimOperation.java
@@ -1,0 +1,48 @@
+package com.handpoint.cordova.sim;
+
+import android.Manifest;
+import android.os.Build;
+
+import org.apache.cordova.*;
+import org.json.JSONArray;
+
+import java.util.logging.Logger;
+
+import org.apache.cordova.CordovaInterface;
+
+public abstract class BaseSimOperation implements SimOperation {
+
+  protected JSONArray args;
+  protected CallbackContext callbackContext;
+  protected CordovaInterface cordova;
+  protected CordovaPlugin cordovaPlugin;
+  protected Logger logger;
+
+  @Override
+  public void initialize(JSONArray args, CallbackContext callbackContext, CordovaInterface cordova,
+      CordovaPlugin cordovaPlugin) {
+    this.args = args;
+    this.callbackContext = callbackContext;
+    this.cordova = cordova;
+    this.cordovaPlugin = cordovaPlugin;
+    this.logger = Logger.getLogger(this.getClass().getSimpleName());
+  }
+
+  @Override
+  public void onRequestPermissionResult(boolean granted) {
+    if (granted) {
+      callbackContext.success();
+    } else {
+      callbackContext.error("Permission denied");
+    }
+  }
+
+  protected boolean simPermissionGranted() {
+    // Below Android 6.0 all permissions are granted at install time
+    if (Build.VERSION.SDK_INT < 23) {
+      return true;
+    }
+    return this.cordova.hasPermission(Manifest.permission.READ_PHONE_STATE);
+  }
+
+}

--- a/src/android/com/handpoint/cordova/sim/GetSimInfoOperation.java
+++ b/src/android/com/handpoint/cordova/sim/GetSimInfoOperation.java
@@ -1,0 +1,93 @@
+package com.handpoint.cordova.sim;
+
+import org.apache.cordova.*;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.apache.cordova.CallbackContext;
+import org.json.JSONObject;
+import org.json.JSONArray;
+import org.json.JSONException;
+import android.content.Context;
+import android.Manifest;
+import android.telephony.SubscriptionInfo;
+import android.telephony.SubscriptionManager;
+import android.telephony.TelephonyManager;
+
+public class GetSimInfoOperation extends BaseSimOperation {
+
+  private static final String PHONE_NUMBER_KEY = "phoneNumber";
+  private static final String DEVICE_ID_KEY = "deviceId";
+  private static final String DEVICE_SOFTWARE_VERSION_KEY = "deviceSoftwareVersion";
+  private static final String SIM_SERIAL_NUMBER_KEY = "simSerialNumber";
+  private static final String SUBSCRIBER_ID_KEY = "subscriberId";
+  private static final String CARRIER_NAME_KEY = "carrierName";
+  private static final String COUNTRY_CODE_KEY = "countryCode";
+  private static final String DATA_ACTIVITY_KEY = "dataActivity";
+  private static final String PHONE_TYPE_KEY = "phoneType";
+  private static final String SIM_STATE_KEY = "simState";
+  private static final String MCC_KEY = "mcc";
+  private static final String MNC_KEY = "mnc";
+
+  private static final String TAG = GetSimInfoOperation.class.getSimpleName();
+  private TelephonyManager manager;
+  private Context context;
+
+  private void addSimInformation(JSONObject result) throws JSONException {
+    if (simPermissionGranted()) {
+      result.put(PHONE_NUMBER_KEY, manager.getLine1Number());
+      result.put(DEVICE_ID_KEY, manager.getDeviceId());
+      result.put(DEVICE_SOFTWARE_VERSION_KEY, manager.getDeviceSoftwareVersion());
+      result.put(SIM_SERIAL_NUMBER_KEY, manager.getSimSerialNumber());
+      result.put(SUBSCRIBER_ID_KEY, manager.getSubscriberId());
+    }
+  }
+
+  private void addGeneralInformation(JSONObject result) throws JSONException {
+    result.put(CARRIER_NAME_KEY, manager.getSimOperatorName());
+    result.put(COUNTRY_CODE_KEY, manager.getSimCountryIso());
+    result.put(DATA_ACTIVITY_KEY, manager.getDataActivity());
+    result.put(PHONE_TYPE_KEY, manager.getPhoneType());
+    result.put(SIM_STATE_KEY, manager.getSimState());
+  }
+
+  private void addCarrierInformation(JSONObject result) throws JSONException {
+    String simOperator = manager.getSimOperator();
+    if (simOperator != null && simOperator.length() >= 3) {
+      result.put(MCC_KEY, simOperator.substring(0, 3));
+      result.put(MNC_KEY, simOperator.substring(3));
+    }
+  }
+
+  private JSONObject buildResult() throws JSONException {
+    JSONObject result = new JSONObject();
+
+    addSimInformation(result);
+    addGeneralInformation(result);
+    addCarrierInformation(result);
+
+    return result;
+  }
+
+  @Override
+  public void initialize(JSONArray args, CallbackContext callbackContext, CordovaInterface cordova,
+      CordovaPlugin cordovaPlugin) {
+    super.initialize(args, callbackContext, cordova, cordovaPlugin);
+    this.context = this.cordova.getActivity().getApplicationContext();
+    this.manager = (TelephonyManager) this.context.getSystemService(Context.TELEPHONY_SERVICE);
+  }
+
+  /**
+   * Executes the process of gathering SIM information and sends the result back
+   * through the callback context
+   *
+   * @throws JSONException If there is an issue with JSON processing.
+   */
+  @Override
+  public void execute() throws JSONException {
+    JSONObject result = buildResult();
+    callbackContext.success(result);
+  }
+
+}

--- a/src/android/com/handpoint/cordova/sim/HasSimReadPermissionOperation.java
+++ b/src/android/com/handpoint/cordova/sim/HasSimReadPermissionOperation.java
@@ -1,0 +1,12 @@
+package com.handpoint.cordova.sim;
+
+import org.json.JSONException;
+
+public class HasSimReadPermissionOperation extends BaseSimOperation {
+
+  @Override
+  public void execute() throws JSONException {
+    callbackContext.success(String.valueOf(simPermissionGranted()));
+  }
+
+}

--- a/src/android/com/handpoint/cordova/sim/RequestSimReadPermissionOperation.java
+++ b/src/android/com/handpoint/cordova/sim/RequestSimReadPermissionOperation.java
@@ -1,0 +1,34 @@
+package com.handpoint.cordova.sim;
+
+import android.Manifest;
+import android.content.pm.PackageManager;
+
+import com.handpoint.cordova.HandpointApiCordova;
+import com.handpoint.cordova.PermissionResultObserver;
+
+import org.apache.cordova.*;
+import org.json.JSONArray;
+import org.json.JSONException;
+
+public class RequestSimReadPermissionOperation extends BaseSimOperation implements PermissionResultObserver {
+
+  public static final int REQUEST_READ_PHONE_STATE = 12000;
+
+  @Override
+  public void execute() throws JSONException {
+    if (!simPermissionGranted()) {
+      ((HandpointApiCordova) this.cordovaPlugin).addPermissionObserver(this);
+      cordova.requestPermission(this.cordovaPlugin, REQUEST_READ_PHONE_STATE, Manifest.permission.READ_PHONE_STATE);
+    } else {
+      callbackContext.success(Boolean.TRUE.toString());
+    }
+  }
+
+  @Override
+  public void onPermissionResult(int requestCode, boolean isGranted) {
+    if (requestCode == REQUEST_READ_PHONE_STATE) {
+      callbackContext.success(isGranted ? Boolean.TRUE.toString() : Boolean.FALSE.toString());
+      ((HandpointApiCordova) this.cordovaPlugin).removePermissionObserver(this);
+    }
+  }
+}

--- a/src/android/com/handpoint/cordova/sim/SimOperation.java
+++ b/src/android/com/handpoint/cordova/sim/SimOperation.java
@@ -1,0 +1,16 @@
+package com.handpoint.cordova.sim;
+
+import org.apache.cordova.*;
+import org.json.JSONArray;
+import org.json.JSONException;
+
+public interface SimOperation {
+
+  void initialize(JSONArray args, CallbackContext callbackContext, CordovaInterface cordova,
+      CordovaPlugin cordovaPlugin);
+
+  void execute() throws JSONException;
+
+  void onRequestPermissionResult(boolean granted);
+
+}

--- a/src/android/com/handpoint/cordova/sim/SimOperationFactory.java
+++ b/src/android/com/handpoint/cordova/sim/SimOperationFactory.java
@@ -1,0 +1,44 @@
+package com.handpoint.cordova.sim;
+
+import org.apache.cordova.*;
+import org.json.JSONArray;
+
+public class SimOperationFactory {
+
+  public static final String GET_SIM_INFO = "getSimInfo";
+  public static final String HAS_READ_PERMISSION = "hasSimReadPermission";
+  public static final String REQUEST_READ_PERMISSION = "requestSimReadPermission";
+
+  public static SimOperation createOperation(String action, JSONArray args, CallbackContext callbackContext,
+      CordovaInterface cordova, CordovaPlugin cordovaPlugin) {
+    switch (action) {
+      case GET_SIM_INFO:
+      case HAS_READ_PERMISSION:
+      case REQUEST_READ_PERMISSION:
+        return getSimOperation(action, args, callbackContext, cordova, cordovaPlugin);
+      default:
+        return null;
+    }
+  }
+
+  private static SimOperation getSimOperation(String action, JSONArray args, CallbackContext callbackContext,
+      CordovaInterface cordova, CordovaPlugin cordovaPlugin) {
+    SimOperation operation;
+    switch (action) {
+      case GET_SIM_INFO:
+        operation = new GetSimInfoOperation();
+        break;
+      case HAS_READ_PERMISSION:
+        operation = new HasSimReadPermissionOperation();
+        break;
+      case REQUEST_READ_PERMISSION:
+        operation = new RequestSimReadPermissionOperation();
+        break;
+      default:
+        throw new IllegalArgumentException("Invalid SIM operation type");
+    }
+    operation.initialize(args, callbackContext, cordova, cordovaPlugin);
+    return operation;
+  }
+
+}

--- a/src/android/pax.gradle
+++ b/src/android/pax.gradle
@@ -18,8 +18,8 @@ repositories{
 dependencies {
    implementation 'com.google.code.gson:gson:2.8.5'
    implementation 'org.slf4j:slf4j-android:1.7.25'
-   implementation ('com.handpoint.api:private-sdk:7.1004.2-RC.19') { changing = true }
-   implementation ('com.handpoint.api:applicationprovider:7.1004.2-RC.19') { changing = true }
+   implementation ('com.handpoint.api:private-sdk:7.1004.2-RC.33-SNAPSHOT') { changing = true }
+   implementation ('com.handpoint.api:applicationprovider:7.1004.2-RC.33-SNAPSHOT') { changing = true }
 }
 
 android {

--- a/www/handpoint.js
+++ b/www/handpoint.js
@@ -871,6 +871,35 @@ Handpoint.prototype.printDetailedLog = function (config, successCallback, errorC
   this.exec('printDetailedLog', config, successCallback, errorCallback);
 };
 
+/**
+ * Gets device SIM info
+ * @param {*} successCallback
+ * @param {*} errorCallback
+ */
+Handpoint.prototype.getSimInfo = function (config, successCallback, errorCallback) {
+  this.exec('getSimInfo', config, successCallback, errorCallback);
+};
+
+/**
+ * It checks if the app has permission to read the SIM card
+ * @param {*} config
+ * @param {*} successCallback
+ * @param {*} errorCallback
+ */
+Handpoint.prototype.hasSimReadPermission = function (config, successCallback, errorCallback) {
+  this.exec('hasSimReadPermission', config, successCallback, errorCallback);
+};
+
+/**
+ * It requests permission to read the SIM card
+ * @param {*} config
+ * @param {*} successCallback
+ * @param {*} errorCallback
+ */
+Handpoint.prototype.requestSimReadPermission = function (config, successCallback, errorCallback) {
+  this.exec('requestSimReadPermission', config, successCallback, errorCallback);
+};
+
 Handpoint.prototype.exec = function (method, config, successCallback, errorCallback) {
 
   if (typeof (config) === 'object') {


### PR DESCRIPTION
SIM activation is not working in Android 10 and above. The reason why it doesn't work is because due to [Android 10 privacy updates](https://developer.android.com/about/versions/10/privacy/changes#non-resettable-device-ids) the method `TelephonyManager.getSimSerialNumber()` requires `READ_PRIVILEGED_PHONE_STATE ` permission to access the device's non-resettable identifiers.

NeptuneLite has a method that allow us to read the SIM serial number without asking for more permissions, so we are falling back to this method whenever we get an Exception while reading the SIM serial number.

We are also moving funcionality from 2 cordova plugins: `cordova-plugin-android-permissions` and `cordova-plugin-sim` to this plugin. The [quality of the plugin code leaves much to be desired](https://github.com/EYALIN/community-cordova-plugin-sim/blob/master/src/android/com/pbakondy/Sim.java), and moreover, implementing the plugin functionality in our own plugin would be easy. Therefore, the decision was made to implement the functionality in our plugin in order to improve maintainability and reduce third-party dependencies.