### PR TITLE
EFTCLIENT-5134 Add Screen Control Methods to Cordova Plugin

### DIFF
--- a/src/android/com/handpoint/cordova/HandpointHelper.java
+++ b/src/android/com/handpoint/cordova/HandpointHelper.java
@@ -1179,6 +1179,15 @@ public class HandpointHelper implements Events.PosRequired, Events.Status, Event
     }
   }
 
+  public void setBrightness(CallbackContext callbackContext, JSONObject params) throws Throwable {
+    try {
+      this.sysManagerWrapper.setBrightness(params.getInt("brightness"));
+      callbackContext.success("ok");
+    } catch (Exception ex) {
+      callbackContext.error("Can't execute getDeviceInfo. Error: " + ex.getMessage());
+    }
+  }
+
   @Override
   protected void finalize() {
     this.api.unregisterEventsDelegate(this);

--- a/src/android/com/handpoint/cordova/HandpointHelper.java
+++ b/src/android/com/handpoint/cordova/HandpointHelper.java
@@ -1188,6 +1188,15 @@ public class HandpointHelper implements Events.PosRequired, Events.Status, Event
     }
   }
 
+  public void turnOffScreen(CallbackContext callbackContext, JSONObject params) throws Throwable {
+    try {
+      this.sysManagerWrapper.turnOffScreen();
+      callbackContext.success("ok");
+    } catch (Exception ex) {
+      callbackContext.error("Can't execute turnOffScreen. Error: " + ex.getMessage());
+    }
+  }
+
   @Override
   protected void finalize() {
     this.api.unregisterEventsDelegate(this);

--- a/src/android/com/handpoint/cordova/SysManagerWrapper.java
+++ b/src/android/com/handpoint/cordova/SysManagerWrapper.java
@@ -34,6 +34,20 @@ public class SysManagerWrapper {
     return deviceInfoBean;
   }
 
+  public void setBrightness(int brightness) {
+    try {
+      // Cargar la clase SysManager dinámicamente
+      Class<?> sysManagerClass = Class.forName("com.handpoint.api.privateops.SysManager");
+
+      // Obtener el método setBrightness
+      Method setBrightnessMethod = sysManagerClass.getDeclaredMethod("setBrightness", int.class);
+      setBrightnessMethod.setAccessible(true);
+      setBrightnessMethod.invoke(null, brightness);
+    } catch (Exception e) {
+      Log.e(TAG, "Error setting brightness via reflection: " + e.getMessage(), e);
+    }
+  }
+
   private CardReaderCapabilitiesBean getCardReaderCapabilities(Class<?> sysManagerClass) {
     try {
       // Obtener el método getCardReaderCapabilities

--- a/src/android/com/handpoint/cordova/SysManagerWrapper.java
+++ b/src/android/com/handpoint/cordova/SysManagerWrapper.java
@@ -11,18 +11,14 @@ public class SysManagerWrapper {
     DeviceInfoBean deviceInfoBean = new DeviceInfoBean();
 
     try {
-      // Cargar la clase SysManager dinámicamente
       Class<?> sysManagerClass = Class.forName("com.handpoint.api.privateops.SysManager");
 
-      // Obtener el número de serie y modelo
       deviceInfoBean.setSerialNumber(invokeStringMethod(sysManagerClass, "getPaxSerialNumber"));
       deviceInfoBean.setModel(invokeStringMethod(sysManagerClass, "getPaxModel"));
 
-      // Obtener las capacidades del lector de tarjetas usando CardReaderCapabilities
       CardReaderCapabilitiesBean cardReaderCapabilitiesBean = getCardReaderCapabilities(sysManagerClass);
       deviceInfoBean.setCardReaderCapabilities(cardReaderCapabilitiesBean);
 
-      // Obtener información adicional desde SysManager
       deviceInfoBean.setSimInfo(invokeStringArrayMethod(sysManagerClass, "getSIMInfo"));
       deviceInfoBean.setDualSIM(invokeBooleanMethod(sysManagerClass, "isDualSIM"));
       deviceInfoBean.setSdkVersion(invokeStringMethod(sysManagerClass, "getSdkVersion"));
@@ -36,10 +32,8 @@ public class SysManagerWrapper {
 
   public void setBrightness(int brightness) {
     try {
-      // Cargar la clase SysManager dinámicamente
       Class<?> sysManagerClass = Class.forName("com.handpoint.api.privateops.SysManager");
 
-      // Obtener el método setBrightness
       Method setBrightnessMethod = sysManagerClass.getDeclaredMethod("setBrightness", int.class);
       setBrightnessMethod.setAccessible(true);
       setBrightnessMethod.invoke(null, brightness);
@@ -48,9 +42,20 @@ public class SysManagerWrapper {
     }
   }
 
+  public void turnOffScreen() {
+    try {
+      Class<?> sysManagerClass = Class.forName("com.handpoint.api.privateops.SysManager");
+
+      Method turnOffScreenMethod = sysManagerClass.getDeclaredMethod("turnOffScreen");
+      turnOffScreenMethod.setAccessible(true);
+      turnOffScreenMethod.invoke(null);
+    } catch (Exception e) {
+      Log.e(TAG, "Error turning off screen via reflection: " + e.getMessage(), e);
+    }
+  }
+
   private CardReaderCapabilitiesBean getCardReaderCapabilities(Class<?> sysManagerClass) {
     try {
-      // Obtener el método getCardReaderCapabilities
       Method getCardReaderCapabilitiesMethod = sysManagerClass.getDeclaredMethod("getCardReaderCapabilities");
       getCardReaderCapabilitiesMethod.setAccessible(true);
       Object capabilities = getCardReaderCapabilitiesMethod.invoke(null);
@@ -58,7 +63,6 @@ public class SysManagerWrapper {
       if (capabilities != null) {
         CardReaderCapabilitiesBean cardReaderCapabilitiesBean = new CardReaderCapabilitiesBean();
 
-        // Usar reflexión para invocar los métodos de CardReaderCapabilities
         Class<?> capabilitiesClass = capabilities.getClass();
 
         cardReaderCapabilitiesBean

--- a/src/android/pax.gradle
+++ b/src/android/pax.gradle
@@ -18,8 +18,8 @@ repositories{
 dependencies {
    implementation 'com.google.code.gson:gson:2.8.5'
    implementation 'org.slf4j:slf4j-android:1.7.25'
-   implementation ('com.handpoint.api:private-sdk:7.1007.0-RC.0-SNAPSHOT') { changing = true }
-   implementation ('com.handpoint.api:applicationprovider:7.1007.0-RC.0-SNAPSHOT') { changing = true }
+   implementation ('com.handpoint.api:private-sdk:7.1007.0-RC.25-SNAPSHOT') { changing = true }
+   implementation ('com.handpoint.api:applicationprovider:7.1007.0-RC.25-SNAPSHOT') { changing = true }
 }
 
 android {

--- a/src/android/pax.gradle
+++ b/src/android/pax.gradle
@@ -18,8 +18,8 @@ repositories{
 dependencies {
    implementation 'com.google.code.gson:gson:2.8.5'
    implementation 'org.slf4j:slf4j-android:1.7.25'
-   implementation ('com.handpoint.api:private-sdk:7.1007.0-RC.1-C-SNAPSHOT') { changing = true }
-   implementation ('com.handpoint.api:applicationprovider:7.1007.0-RC.1-C-SNAPSHOT') { changing = true }
+   implementation ('com.handpoint.api:private-sdk:7.1007.0-RC.0-SNAPSHOT') { changing = true }
+   implementation ('com.handpoint.api:applicationprovider:7.1007.0-RC.0-SNAPSHOT') { changing = true }
 }
 
 android {

--- a/src/android/pax.gradle
+++ b/src/android/pax.gradle
@@ -18,8 +18,8 @@ repositories{
 dependencies {
    implementation 'com.google.code.gson:gson:2.8.5'
    implementation 'org.slf4j:slf4j-android:1.7.25'
-   implementation ('com.handpoint.api:private-sdk:7.1007.0-RC.0-SNAPSHOT') { changing = true }
-   implementation ('com.handpoint.api:applicationprovider:7.1007.0-RC.0-SNAPSHOT') { changing = true }
+   implementation ('com.handpoint.api:private-sdk:7.1007.0-RC.1-C-SNAPSHOT') { changing = true }
+   implementation ('com.handpoint.api:applicationprovider:7.1007.0-RC.1-C-SNAPSHOT') { changing = true }
 }
 
 android {

--- a/src/android/pax.gradle
+++ b/src/android/pax.gradle
@@ -18,8 +18,8 @@ repositories{
 dependencies {
    implementation 'com.google.code.gson:gson:2.8.5'
    implementation 'org.slf4j:slf4j-android:1.7.25'
-   implementation ('com.handpoint.api:private-sdk:7.1007.0-RC.25-SNAPSHOT') { changing = true }
-   implementation ('com.handpoint.api:applicationprovider:7.1007.0-RC.25-SNAPSHOT') { changing = true }
+   implementation ('com.handpoint.api:private-sdk:7.1007.0-RC.0-SNAPSHOT') { changing = true }
+   implementation ('com.handpoint.api:applicationprovider:7.1007.0-RC.0-SNAPSHOT') { changing = true }
 }
 
 android {

--- a/www/handpoint.js
+++ b/www/handpoint.js
@@ -730,6 +730,17 @@ Handpoint.prototype.getDeviceInfo = function (successCallback, errorCallback) {
 };
 
 /**
+ * Set the brightness of the device
+ * @param {*} config Config object with the brightness value
+ *  - config.brightness The brightness value to set
+ * @param {*} successCallback
+ * @param {*} errorCallback
+ */
+Handpoint.prototype.setBrightness = function (config, successCallback, errorCallback) {
+  this.exec('setBrightness', config, successCallback, errorCallback);
+};
+
+/**
  * Show location setting dialog
  * @param config.text Text to be shown
  * @param config.okBtnText Accept button text

--- a/www/handpoint.js
+++ b/www/handpoint.js
@@ -741,6 +741,15 @@ Handpoint.prototype.setBrightness = function (config, successCallback, errorCall
 };
 
 /**
+ * Turn off the screen of the device
+ * @param {*} successCallback
+ * @param {*} errorCallback
+ */
+Handpoint.prototype.turnOffScreen = function (successCallback, errorCallback) {
+  this.exec('turnOffScreen', {}, successCallback, errorCallback);
+};
+
+/**
  * Show location setting dialog
  * @param config.text Text to be shown
  * @param config.okBtnText Accept button text


### PR DESCRIPTION
This PR introduces two new methods to our Cordova plugin: `setBrightness` and `turnOffScreen`. These methods provide additional control over the device's screen, allowing the application to adjust the screen brightness and turn off the screen programmatically.

## Implementation Notes
Both methods utilize reflection to access the **SysManager** class through the **SysManagerWrapper**. The `SysManager` class is only accessible via the `private-ops` package, which is dynamically linked in our production builds. This package is not available to integrators and is specifically used in our internal operations.

The addition of these methods aims to enhance device control capabilities, particularly in scenarios where screen management is critical for the application's functionality.
