### PR TITLE
fix: Enable HTTP on nexus repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-handpoint",
-  "version": "4.13.0-RC.27",
+  "version": "4.13.0-RC.99",
   "description": "Cordova Handpoint SDK Plugin",
   "cordova": {
     "id": "cordova-plugin-handpoint",

--- a/src/android/pax.gradle
+++ b/src/android/pax.gradle
@@ -20,9 +20,9 @@ repositories{
 dependencies {
    implementation 'com.google.code.gson:gson:2.8.5'
    implementation 'org.slf4j:slf4j-android:1.7.25'
-   implementation ('com.handpoint.api:sdk:7.1013.0-RC.27-SNAPSHOT') { changing = true }
-   implementation ('com.handpoint.api:privateops:7.1013.0-RC.27-SNAPSHOT') { changing = true }
-   implementation ('com.handpoint.api:applicationprovider:7.1013.0-RC.27-SNAPSHOT') { changing = true }
+   implementation ('com.handpoint.api:sdk:7.1013.0-RC.99-SNAPSHOT') { changing = true }
+   implementation ('com.handpoint.api:privateops:7.1013.0-RC.99-SNAPSHOT') { changing = true }
+   implementation ('com.handpoint.api:applicationprovider:7.1013.0-RC.99-SNAPSHOT') { changing = true }
 }
 
 android {

--- a/src/android/pax.gradle
+++ b/src/android/pax.gradle
@@ -5,6 +5,7 @@ repositories{
       password getCredentialsMavenPassword()
     }
     url = "http://nexus.handpoint.ninja:8081/repository/maven-public/"
+    allowInsecureProtocol = true
   }
   maven {
     credentials {
@@ -12,15 +13,17 @@ repositories{
       password getCredentialsMavenPassword()
     }
     url = "http://nexus.handpoint.ninja:8081/repository/maven-releases/"
+    allowInsecureProtocol = true
   }
 }
 
 dependencies {
    implementation 'com.google.code.gson:gson:2.8.5'
    implementation 'org.slf4j:slf4j-android:1.7.25'
-   implementation ('com.handpoint.api:sdk:7.1012.0-RC.0-SNAPSHOT') { changing = true }
-   implementation ('com.handpoint.api:privateops:7.1012.0-RC.0-SNAPSHOT') { changing = true }
-   implementation ('com.handpoint.api:applicationprovider:7.1012.0-RC.0-SNAPSHOT') { changing = true }
+   implementation ('com.handpoint.api:sdk:7.1013.0-RC.27-SNAPSHOT') { changing = true }
+   implementation ('com.handpoint.api:paymentsdk:7.1013.0-RC.27-SNAPSHOT') { changing = true }
+   implementation ('com.handpoint.api:privateops:7.1013.0-RC.27-SNAPSHOT') { changing = true }
+   implementation ('com.handpoint.api:applicationprovider:7.1013.0-RC.27-SNAPSHOT') { changing = true }
 }
 
 android {

--- a/src/android/pax.gradle
+++ b/src/android/pax.gradle
@@ -21,7 +21,6 @@ dependencies {
    implementation 'com.google.code.gson:gson:2.8.5'
    implementation 'org.slf4j:slf4j-android:1.7.25'
    implementation ('com.handpoint.api:sdk:7.1013.0-RC.27-SNAPSHOT') { changing = true }
-   implementation ('com.handpoint.api:paymentsdk:7.1013.0-RC.27-SNAPSHOT') { changing = true }
    implementation ('com.handpoint.api:privateops:7.1013.0-RC.27-SNAPSHOT') { changing = true }
    implementation ('com.handpoint.api:applicationprovider:7.1013.0-RC.27-SNAPSHOT') { changing = true }
 }


### PR DESCRIPTION
Enable the HTTP on nexus repo due to the update on gradle, now Gradle by default does not allow HTTP